### PR TITLE
Improve company selector readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,24 @@
             cursor: pointer;
             opacity: 0.7;
             border: 3px solid transparent;
-            padding: 0.5rem;
-            border-radius: 0.5rem;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            min-width: 120px;
+            text-align: center;
+        }
+        .company-logo img {
+            max-height: 3rem;
+        }
+        .company-name {
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: #2f3c32;
+            line-height: 1.4;
         }
         .company-logo:hover {
             filter: grayscale(0%);
@@ -357,7 +373,7 @@
             updateActiveState();
             
             const companyData = {
-                'linepay': { name: 'LINE PAY', logo: 'https://placehold.co/100x50/FFFFFF/000000?text=LINE+Pay&font=noto+sans+tc', tier: '第一梯隊', score: [5, 5, 5, 4, 5], analysis: { good: '展現最專業的表現，從虧損到獲利的數據故事線清晰，策略邏輯完整，視覺化呈現優秀。', bad: '缺乏與同業(如街口支付)的橫向比較，對未來支付生態系的競爭格局可以有更深入的論述。' }},
+                'linepay': { name: 'LINE Pay', logo: 'https://placehold.co/100x50/FFFFFF/000000?text=LINE+Pay&font=noto+sans+tc', tier: '第一梯隊', score: [5, 5, 5, 4, 5], analysis: { good: '展現最專業的表現，從虧損到獲利的數據故事線清晰，策略邏輯完整，視覺化呈現優秀。', bad: '缺乏與同業(如街口支付)的橫向比較，對未來支付生態系的競爭格局可以有更深入的論述。' }},
                 'daiken': { name: '大研生醫', logo: 'https://placehold.co/100x50/FFFFFF/000000?text=%E5%A4%A7%E7%A0%94%E7%94%9F%E9%86%AB&font=noto+sans+tc', tier: '第二梯隊', score: [4, 4, 4, 2, 4], analysis: { good: '運用「七大戰略引擎」概念展現系統性思維，品牌代言人策略成功，營收與毛利表現亮眼。', bad: '對庫存週轉天數飆升(53→214天)與負債比率攀升(39%→67%)的風險溝通不足，需主動解釋。' }},
                 'bafang': { name: '八方雲集', logo: 'https://placehold.co/100x50/FFFFFF/000000?text=%E5%85%AB%E6%96%B9%E9%9B%B2%E9%9B%86&font=noto+sans+tc', tier: '第三梯隊', score: [3, 3, 2, 2, 3], analysis: { good: '企業歷史脈絡與多品牌矩陣清晰，費用率管理穩定，區域佔比等數據透明。', bad: '近年食安事件的處理說明不夠充分，對負面消息的處理顯得被動，需要更積極的危機溝通策略。' }},
                 'gogolook': { name: 'Gogolook', logo: 'https://placehold.co/100x50/FFFFFF/000000?text=Gogolook&font=noto+sans+tc', tier: '第三梯隊', score: [4, 3, 3, 2, 4], analysis: { good: '產業痛點與產品矩陣的敘事清楚，具備AI信任科技領導者的宏大願景與技術護城河。', bad: '市場預期管理面臨挑戰(年跌幅-42.57%)，需更有效解釋獲利轉機與國際擴張策略，將社會價值轉化為投資價值。' }},
@@ -374,12 +390,19 @@
                 wrapper.className = 'company-logo';
                 wrapper.dataset.company = key;
                 
-                const logoEl = document.createElement('img');
-                logoEl.src = company.logo;
-                logoEl.alt = company.name;
-                logoEl.className = 'h-12 w-auto object-contain';
-                
-                wrapper.appendChild(logoEl);
+                if (company.logo) {
+                    const logoEl = document.createElement('img');
+                    logoEl.src = company.logo;
+                    logoEl.alt = company.name;
+                    logoEl.className = 'h-12 w-auto object-contain';
+                    wrapper.appendChild(logoEl);
+                }
+
+                const nameEl = document.createElement('span');
+                nameEl.textContent = company.name;
+                nameEl.className = 'company-name';
+
+                wrapper.appendChild(nameEl);
                 selectorContainer.appendChild(wrapper);
             });
             


### PR DESCRIPTION
## Summary
- show each company's name beneath its selector tile so the full label is visible even when placeholder logos fail to render correctly
- tweak the selector styling to align text-centered layouts and adjust the LINE Pay label casing

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68caa218218c8326baf0bb88c71e03c0