### PR TITLE
Adjust radar label size and widen company cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             cursor: pointer;
             opacity: 0.7;
             border: 3px solid transparent;
-            padding: 0.75rem 1rem;
+            padding: 0.75rem 1.25rem;
             border-radius: 0.75rem;
             display: flex;
             flex-direction: column;
@@ -64,7 +64,7 @@
             gap: 0.5rem;
             min-width: 120px;
             text-align: center;
-            flex: 0 0 220px;
+            flex: 0 0 260px;
         }
         .company-logo img {
             max-height: 3rem;
@@ -513,7 +513,7 @@
                                 },
                                 pointLabels: {
                                     font: {
-                                        size: 10
+                                        size: 9
                                     },
                                     color: '#4B5563',
                                     padding: 8
@@ -601,7 +601,7 @@
                             },
                             pointLabels: {
                                 font: {
-                                    size: 12
+                                    size: 10
                                 },
                                 color: '#333',
                                 padding: 12


### PR DESCRIPTION
## Summary
- shrink radar chart point label fonts for the mini and main charts to improve readability
- widen each company card and add extra horizontal padding for a roomier layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab06b68288326bcd24aec681999e2