### PR TITLE
Prevent radar controls from wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
             </div>
             <div class="card">
                 <h3 class="font-bold text-xl mb-4 text-center">綜合評分與比較雷達圖</h3>
-                <div id="radarControls" class="flex flex-wrap justify-center gap-3 mb-4"></div>
+                <div id="radarControls" class="flex flex-nowrap justify-center gap-3 mb-4 overflow-x-auto"></div>
                 <div class="chart-container">
                     <canvas id="companyRadarChart"></canvas>
                 </div>
@@ -638,7 +638,7 @@
             const radarControlsContainer = document.getElementById('radarControls');
             radarDataSets.forEach((dataset, index) => {
                 const controlLabel = document.createElement('label');
-                controlLabel.className = 'flex items-center gap-2 bg-[#f3f7f2] px-3 py-1 rounded-full cursor-pointer text-sm text-gray-700 shadow-sm';
+                controlLabel.className = 'flex items-center gap-2 bg-[#f3f7f2] px-3 py-1 rounded-full cursor-pointer text-sm text-gray-700 shadow-sm whitespace-nowrap shrink-0';
 
                 const checkbox = document.createElement('input');
                 checkbox.type = 'checkbox';


### PR DESCRIPTION
## Summary
- keep the radar chart legend controls on one row by preventing flex wrapping and allowing horizontal scrolling
- ensure each control chip stays on a single line by adding whitespace and flex shrink guards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cab19604f883269bf805992a906e38